### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -429,7 +429,13 @@ export const getStaticProps: GetStaticProps<BlogPostProps, IParams> = async ({ p
 
   try {
     const { slug } = params;
-    const filePath = path.join(process.cwd(), 'content/blog', `${slug}.md`);
+    const rootDir = path.join(process.cwd(), 'content/blog');
+    const filePath = path.resolve(rootDir, `${slug}.md`);
+    if (!filePath.startsWith(rootDir)) {
+      return {
+        notFound: true
+      };
+    }
     const fileContents = fs.readFileSync(filePath, 'utf8');
     const { data: frontMatter, content } = matter(fileContents);
     


### PR DESCRIPTION
Fixes [https://github.com/Achim-Sommer/nextjs-portfolio/security/code-scanning/2](https://github.com/Achim-Sommer/nextjs-portfolio/security/code-scanning/2)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root folder. This will prevent directory traversal attacks by ensuring that the file path does not escape the intended directory.

1. Normalize the file path using `path.resolve`.
2. Check that the normalized path starts with the root folder.
3. If the check fails, return a 404 response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
